### PR TITLE
Expose HotkeyManager index for tests

### DIFF
--- a/Webbing/HotkeyManager.swift
+++ b/Webbing/HotkeyManager.swift
@@ -9,7 +9,7 @@ final class HotkeyManager {
   private weak var store: ClipboardStore?
   private weak var menuBar: MenuBarController?
   
-  private var currentIndex = 0 { didSet { menuBar?.flash(index: currentIndex) } }
+  internal(set) var currentIndex = 0 { didSet { menuBar?.flash(index: currentIndex) } }
   
   // MARK: ‑ Setup
   func configure(store: ClipboardStore, menuBar: MenuBarController) {
@@ -99,3 +99,12 @@ extension String {
     return result
   }
 }
+
+#if DEBUG
+extension HotkeyManager {
+  /// Test helper to invoke actions directly without hotkeys.
+  func testHandle(_ action: Action) {
+    handle(action)
+  }
+}
+#endif

--- a/WebbingTests/WebbingTests.swift
+++ b/WebbingTests/WebbingTests.swift
@@ -26,11 +26,11 @@ final class WebbingTests: XCTestCase {
   func testIndexCycling() throws {
     let hk = HotkeyManager(); let store = ClipboardStore(); let fakeMenu = MenuBarController(store: store, hotkeys: hk)
     hk.configure(store: store, menuBar: fakeMenu)
-    hk.perform("prev") // custom test hook
+    hk.testHandle(.prev)
     XCTAssertEqual(hk.currentIndex, 9)
-    hk.perform("next")
+    hk.testHandle(.next)
     XCTAssertEqual(hk.currentIndex, 0)
-    hk.perform("reset")
+    hk.testHandle(.reset)
     XCTAssertEqual(hk.currentIndex, 0)
   }
 }


### PR DESCRIPTION
## Summary
- make `HotkeyManager.currentIndex` internal(set)
- add a debug-only `testHandle` helper to HotkeyManager
- update unit tests to use `testHandle` instead of `perform("…")`

## Testing
- `swiftformat .` *(fails: command not found)*
- `swiftlint` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68583cd68cc4832d812d29363cde83ad